### PR TITLE
fix(backend): enable CORS policy to allow frontend API calls

### DIFF
--- a/backend/BookApi/Program.cs
+++ b/backend/BookApi/Program.cs
@@ -10,6 +10,14 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll",
+        policy => policy.AllowAnyOrigin()
+                        .AllowAnyMethod()
+                        .AllowAnyHeader());
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -20,6 +28,7 @@ if (app.Environment.IsDevelopment())
     });
 }
 
+app.UseCors("AllowAll");
 app.UseAuthorization();
 app.MapControllers();
 app.Run();


### PR DESCRIPTION
Adds CORS to the backend to allow Angular to make API requests.

Added `AllowAll` CORS policy in `Program.cs.`